### PR TITLE
【Fixed】Issues#64  対応、ユーザ別に各ユーザの削除可否、および　チームの編集可否を追加

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -16,7 +16,9 @@ class AssignsController < ApplicationController
 
   def destroy
     assign = Assign.find(params[:id])
-    destroy_message = assign_destroy(assign, assign.user)
+    if (find_team(params[:team_id]).owner_id == current_user.id) || (assign.user_id == current_user.id)
+      destroy_message = assign_destroy(assign, assign.user)
+    end
 
     redirect_to team_url(params[:team_id]), notice: destroy_message
   end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,11 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    binding.pry
+#    redirect_to team_url(params[:team_id]) # params[:team_id] = nil なので多分エラー
+    redirect_to team_url(params[:id]) unless (set_team.owner_id == current_user.id)
+  end
 
   def create
     @team = Team.new(team_params)


### PR DESCRIPTION
Issues#64  の  対応

```
- Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないように変更
- TeamのeditはTeamのリーダー（オーナー）のみができるように変更
```