### PR TITLE
Issues#67

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -15,10 +15,18 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
     end
+  end
+
+  def destroy
+    @agenda.destroy
+    @agenda.team.members.each do |member|
+      AssignMailer.delete_agenda_mail(member, @agenda).deliver
+    end
+    redirect_to dashboard_url, notice: I18n.t('views.messages.delete_agenda')
   end
 
   private

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -64,7 +64,7 @@ class AssignsController < ApplicationController
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id
   end
 
-  def find_team(team_id)
+  def find_team(_team_id)
     Team.friendly.find(params[:team_id])
   end
 end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -15,7 +15,6 @@ class AssignsController < ApplicationController
   end
 
   def destroy
-    binding.pry
     assign = Assign.find(params[:id])
     if (find_team(params[:team_id]).owner_id == current_user.id) || (assign.user_id == current_user.id)
       destroy_message = assign_destroy(assign, assign.user)

--- a/app/mailers/assign_mailer.rb
+++ b/app/mailers/assign_mailer.rb
@@ -12,4 +12,10 @@ class AssignMailer < ApplicationMailer
     @team_name = team_name
     mail to: @email, subject: I18n.t('views.messages.switch_leader')
   end
+
+  def delete_agenda_mail(member, agenda)
+    @email = member.email
+    @agenda_name = agenda.title
+    mail to: @email, subject: I18n.t('views.messages.delete_agenda')
+  end
 end

--- a/app/models/agenda.rb
+++ b/app/models/agenda.rb
@@ -2,4 +2,5 @@ class Agenda < ApplicationRecord
   belongs_to :team
   belongs_to :user
   has_many :articles, dependent: :destroy
+  validates :title, presence: true
 end

--- a/app/views/assign_mailer/delete_agenda_mail.html.erb
+++ b/app/views/assign_mailer/delete_agenda_mail.html.erb
@@ -1,0 +1,4 @@
+<h1><%= I18n.t('views.messages.delete_agenda') %></h1>
+
+<h4>email: <%= @email %></h4>
+<p>アジェンダ名：<%= @agenda_name %>　は削除されました。</p>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -34,7 +34,7 @@
               <i class="fa fa-circle-o nav-icon"></i>
               <a>
                 <%= agenda.title %>
-                <%= link_to '削除', dashboard_path(agenda), class: 'btn btn-sm btn-danger' %>
+                <%= link_to '削除', agenda_path(agenda), method: :delete, class: 'btn btn-sm btn-danger' if (current_user.id == agenda.user_id) || (current_user.id == @team.owner_id) %>
                 <i class="right fa fa-angle-left"></i>
               </a>
             </p>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -30,13 +30,14 @@
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
+            <p href="#" class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>
-              <p>
+              <a>
                 <%= agenda.title %>
+                <%= link_to '削除', dashboard_path(agenda), class: 'btn btn-sm btn-danger' %>
                 <i class="right fa fa-angle-left"></i>
-              </p>
-            </a>
+              </a>
+            </p>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -254,6 +254,7 @@ ja:
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
       switch_leader: 'あなたは次のリーダーに任命されました！'
+      delete_agenda: 'アジェンダが削除されました'
     button:
       submit: '投稿'
       edit: '編集'


### PR DESCRIPTION
#1 

issue#67 ；アジェンダの削除機能を実装すること<br>（紐づいている記事も削除し、そのアジェンダのチームに属しているメンバー全員に通知メールを送信すること）


> -   AgendasControllerのdestroyアクションを追加し、そこに機能追加する
> -   Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
> -   Agendaに紐づいているarticleも一緒に削除される
> -   Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
> -   Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ
> - 情報処理が完了した後はDashBoardに飛ぶ
> - その他、アプリケーションの挙動に不審な点やエラーがないこと
> - RuboCopチェックを行い、Warning（警告）以上の違反がないこと（クローンした初期の状態でWarningが発生します。問題となっている箇所を確認し、コードを修正してください）
